### PR TITLE
USPS 503 issue

### DIFF
--- a/lib/address_validate/api.rb
+++ b/lib/address_validate/api.rb
@@ -7,7 +7,7 @@ module AddressValidate
       response = Net::HTTP.post_form(URI(AddressValidate.verify_url),
         { API: 'Verify',
           XML: Request.build_xml(data) })
-      Response.new(response.body)
+      AddressValidate::API::Response.new(response.code == "200" ? response.body : "#{response.code} #{response.message}")
     end
   end
 end

--- a/lib/address_validate/api/response.rb
+++ b/lib/address_validate/api/response.rb
@@ -5,6 +5,8 @@ module AddressValidate
 
       def initialize(response_body)
         @response_body = Ox.parse(response_body)
+      rescue Ox::ParseError => e
+        @errors = "Error converting result: #{e.message} (#{response_body})"
       end
 
       def success?

--- a/lib/address_validate/version.rb
+++ b/lib/address_validate/version.rb
@@ -1,3 +1,3 @@
 module AddressValidate
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/address_validate/api_spec.rb
+++ b/spec/address_validate/api_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe AddressValidate::API do
   let(:usps_response) { AddressValidate::Test::Fixtures.load_fixture('api_response_success.xml') }
-  let(:response) { double(body: usps_response) }
+  let(:response) { double(code: '200', body: usps_response) }
   before { allow(Net::HTTP).to receive(:post_form).and_return(response) }
 
   it 'returns a response object' do


### PR DESCRIPTION
Instability occurring when consuming the service and error 503 occurs.

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/35971ee3-3333-465a-b282-8516db7234cc" />


This error does not return XML as a response, but rather HTML, causing an error when parsing the result.

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/941b5218-7267-4c0d-bedb-e5ca17db007e" />

https://github.com/Line5LLC/line5/pull/4169
